### PR TITLE
Alpha color utility

### DIFF
--- a/modules/react/common/lib/theming/palette/alpha.ts
+++ b/modules/react/common/lib/theming/palette/alpha.ts
@@ -1,0 +1,199 @@
+/**
+ * Alpha compositing utilities for transparent colors over a background.
+ * Porter-Duff blending. @see https://www.w3.org/TR/compositing-1/
+ */
+
+import type {RGB} from './types';
+import {hexToRgb, clamp} from './conversion';
+
+/**
+ * Result of transparent color calculation
+ */
+export interface AlphaColorResult {
+  /** RGB channels (values 0-1) */
+  color: RGB;
+  /** Alpha channel (0-1) */
+  alpha: number;
+  /** CSS rgba(r, g, b, a) string */
+  rgba: string;
+  /** Hex with alpha (#RRGGBBAA) */
+  hex: string;
+}
+
+/**
+ * Checks if color is a valid RGB tuple
+ */
+const isRGB = (color: RGB, param: string): void => {
+  if (!Array.isArray(color) || color.length !== 3) {
+    throw new TypeError(`${param} must be an RGB tuple [r, g, b]`);
+  }
+  if (
+    typeof color[0] !== 'number' ||
+    typeof color[1] !== 'number' ||
+    typeof color[2] !== 'number'
+  ) {
+    throw new TypeError(`${param} must contain numeric values`);
+  }
+  if (!isFinite(color[0]) || !isFinite(color[1]) || !isFinite(color[2])) {
+    throw new RangeError(`${param} values must be finite numbers`);
+  }
+};
+
+const parseColor = (input: RGB | string): RGB =>
+  typeof input === 'string' ? hexToRgb(input) : input;
+
+/**
+ * Minimum transparency needed to represent the solid color with the specified background.
+ * @param color - Target RGB (0-1)
+ * @param bgColor - Background RGB (0-1)
+ * @returns Alpha 0.01-0.99
+ */
+export const minAlpha = (color: RGB, bgColor: RGB): number => {
+  isRGB(color, 'color');
+  isRGB(bgColor, 'bgColor');
+
+  let result = 0.01;
+
+  for (let i = 0; i < 3; i++) {
+    const out = color[i];
+    const bg = bgColor[i];
+    // When the channel values are very close, we can assume they are the same.
+    if (Math.abs(out - bg) < 0.0001) {
+      continue;
+    }
+
+    const required = out > bg ? (out - bg) / (1 - bg) : (bg - out) / bg;
+    if (required > result && required <= 1) {
+      result = required;
+    }
+  }
+
+  return clamp(result, 0, 1) * 0.99 + 0.01;
+};
+
+const alphaChannel = (target: number, bg: number, a: number): number => {
+  if (a <= 0.001) {
+    return target;
+  }
+  return clamp((target - bg * (1 - a)) / a, 0, 1);
+};
+
+/**
+ * Calculates an alpha color that composites to the target over the background.
+ * Inverse of composite: composite(alpha(target, bg, a), bg, a) equals target.
+ *
+ * @param color - Target color as RGB tuple (values 0-1)
+ * @param bgColor - Background color as RGB tuple (values 0-1)
+ * @param a - Alpha (0-1)
+ * @returns Transparent RGB tuple that composites to color over bgColor
+ */
+export const alpha = (color: RGB, bgColor: RGB, a: number): RGB => [
+  alphaChannel(color[0], bgColor[0], a),
+  alphaChannel(color[1], bgColor[1], a),
+  alphaChannel(color[2], bgColor[2], a),
+];
+
+/**
+ * Composites a color with alpha over a background.
+ * Output = alpha × Foreground + (1 - alpha) × Background
+ *
+ * @param color - Foreground color as RGB tuple (values 0-1)
+ * @param bgColor - Background color as RGB tuple (values 0-1)
+ * @param a - Alpha (0-1), clamped
+ * @returns Composited RGB tuple
+ *
+ * @example
+ * composite([0,0,0], [1,1,1], 0.5) // [0.5, 0.5, 0.5]
+ */
+export const composite = (color: RGB, bgColor: RGB, a: number): RGB => {
+  const clamped = clamp(a, 0, 1);
+  return [
+    clamped * color[0] + (1 - clamped) * bgColor[0],
+    clamped * color[1] + (1 - clamped) * bgColor[1],
+    clamped * color[2] + (1 - clamped) * bgColor[2],
+  ];
+};
+
+/**
+ * Formats RGB tuple to CSS rgb() or rgba() string
+ *
+ * @param color - RGB tuple (values 0-1)
+ * @param alpha - If omitted, rgb(); if provided, rgba()
+ * @returns CSS color string
+ */
+export const formatRGBA = (color: RGB, alpha?: number): string => {
+  const r = Math.round(clamp(color[0], 0, 1) * 255);
+  const g = Math.round(clamp(color[1], 0, 1) * 255);
+  const b = Math.round(clamp(color[2], 0, 1) * 255);
+  if (alpha === undefined) {
+    return `rgb(${r}, ${g}, ${b})`;
+  }
+  return `rgba(${r}, ${g}, ${b}, ${clamp(alpha, 0, 1).toFixed(2)})`;
+};
+
+/**
+ * Converts RGB tuple to hex string
+ *
+ * @param color - RGB tuple (values 0-1)
+ * @param alpha - If omitted, #RRGGBB; if provided, #RRGGBBAA
+ * @returns Hex string (#RRGGBB or #RRGGBBAA)
+ */
+export const rgbToHex = (color: RGB, alpha?: number): string => {
+  const toHex = (v: number) =>
+    Math.round(clamp(v, 0, 1) * 255)
+      .toString(16)
+      .padStart(2, '0');
+  const hex = `#${toHex(color[0])}${toHex(color[1])}${toHex(color[2])}`;
+  if (alpha === undefined) {
+    return hex;
+  }
+  return `${hex}${toHex(alpha)}`;
+};
+
+/**
+ * Calculates an alpha color that appears identical when composited over the background.
+ * Accepts either RGB tuples or hex strings (#RGB, #RRGGBB).
+ *
+ * @param color - Target color as RGB tuple (values 0-1)
+ * @param bg - Background as RGB tuple (default: white [1,1,1])
+ * @param targetAlpha - Alpha (0-1). Omit to use minimum required.
+ * @returns {AlphaColorResult}
+ * @throws {TypeError} Invalid color/bg or targetAlpha
+ * @throws {RangeError} NaN or Infinity in color values
+ * @throws {Error} Invalid hex format
+ *
+ * @example
+ * alphaColor([0.5,0.5,0.5], [1,1,1])
+ * alphaColor('#0875E1', '#FFFFFF', 0.85)
+ */
+export function alphaColor(color: RGB, bg?: RGB, targetAlpha?: number): AlphaColorResult;
+export function alphaColor(
+  hexColor: string,
+  bgHex?: string,
+  targetAlpha?: number
+): AlphaColorResult;
+export function alphaColor(
+  colorOrHex: RGB | string,
+  bg?: RGB | string,
+  targetAlpha?: number
+): AlphaColorResult {
+  if (targetAlpha !== undefined && (typeof targetAlpha !== 'number' || !isFinite(targetAlpha))) {
+    throw new TypeError('targetAlpha must be a finite number between 0 and 1');
+  }
+
+  const color = parseColor(colorOrHex);
+  const bgColor = bg !== undefined ? parseColor(bg) : ([1, 1, 1] as RGB);
+
+  isRGB(color, 'color');
+  isRGB(bgColor, 'bgColor');
+
+  const a = targetAlpha !== undefined ? clamp(targetAlpha, 0, 1) : minAlpha(color, bgColor);
+  const transparent = alpha(color, bgColor, a);
+
+  return {
+    color: transparent,
+    alpha: a,
+    rgba: formatRGBA(transparent, a),
+    hex: rgbToHex(transparent, a),
+  };
+}

--- a/modules/react/common/lib/theming/palette/index.ts
+++ b/modules/react/common/lib/theming/palette/index.ts
@@ -42,5 +42,10 @@ export {
 // Re-export gamut utilities for advanced use cases
 export {computeMaxChroma, computeMaxChromaForGamuts, isInGamut, mapToGamut} from './gamut';
 
+// Re-export alpha/transparency utilities
+export {minAlpha, alpha, composite, formatRGBA, rgbToHex, alphaColor} from './alpha';
+
+export type {AlphaColorResult} from './alpha';
+
 // Re-export Color class for advanced use cases
 export {default as Color} from 'colorjs.io';

--- a/modules/react/common/spec/Alpha.spec.tsx
+++ b/modules/react/common/spec/Alpha.spec.tsx
@@ -1,0 +1,327 @@
+import type {RGB} from '../lib/theming/palette/types';
+import {hexToRgb} from '../lib/theming/palette/conversion';
+import {
+  minAlpha,
+  alpha,
+  composite,
+  formatRGBA,
+  rgbToHex,
+  alphaColor,
+} from '../lib/theming/palette/alpha';
+
+describe('alpha utilities', () => {
+  describe('minAlpha', () => {
+    it('should calculate minimum alpha for high contrast colors', () => {
+      const black: RGB = [0, 0, 0];
+      const white: RGB = [1, 1, 1];
+      expect(minAlpha(black, white)).toBeGreaterThan(0.9);
+    });
+
+    it('should calculate minimum alpha for low contrast colors', () => {
+      const lightGray: RGB = [0.9, 0.9, 0.9];
+      const white: RGB = [1, 1, 1];
+      expect(minAlpha(lightGray, white)).toBeLessThan(0.2);
+    });
+
+    it('should return minimum alpha for identical colors', () => {
+      const color: RGB = [0.5, 0.5, 0.5];
+      const result = minAlpha(color, color);
+      expect(result).toBeCloseTo(0.02, 2);
+      expect(result).toBeGreaterThanOrEqual(0.01);
+    });
+
+    it('should handle dark color on dark background', () => {
+      const darkGray: RGB = [0.2, 0.2, 0.2];
+      const black: RGB = [0, 0, 0];
+      const result = minAlpha(darkGray, black);
+      expect(result).toBeGreaterThan(0);
+      expect(result).toBeLessThan(1);
+    });
+
+    it('should never exceed 0.99', () => {
+      const color1: RGB = [0.5, 0.3, 0.8];
+      const color2: RGB = [0, 0, 0];
+      expect(minAlpha(color1, color2)).toBeLessThanOrEqual(0.99);
+    });
+  });
+
+  describe('alpha', () => {
+    it('should calculate transparent color that composites to target', () => {
+      const target: RGB = [0.5, 0.5, 0.5];
+      const bg: RGB = [1, 1, 1];
+      const a = 0.5;
+      const transparent = alpha(target, bg, a);
+      const composited = composite(transparent, bg, a);
+      expect(composited[0]).toBeCloseTo(target[0], 2);
+      expect(composited[1]).toBeCloseTo(target[1], 2);
+      expect(composited[2]).toBeCloseTo(target[2], 2);
+    });
+
+    it('should handle alpha = 1 (fully opaque)', () => {
+      const target: RGB = [0.3, 0.6, 0.9];
+      const bg: RGB = [1, 1, 1];
+      const transparent = alpha(target, bg, 1);
+      expect(transparent[0]).toBeCloseTo(target[0], 2);
+      expect(transparent[1]).toBeCloseTo(target[1], 2);
+      expect(transparent[2]).toBeCloseTo(target[2], 2);
+    });
+
+    it('should clamp values between 0 and 1', () => {
+      const target: RGB = [0.9, 0.9, 0.9];
+      const bg: RGB = [0.8, 0.8, 0.8];
+      const transparent = alpha(target, bg, 0.1);
+      expect(transparent[0]).toBeGreaterThanOrEqual(0);
+      expect(transparent[0]).toBeLessThanOrEqual(1);
+      expect(transparent[1]).toBeGreaterThanOrEqual(0);
+      expect(transparent[1]).toBeLessThanOrEqual(1);
+      expect(transparent[2]).toBeGreaterThanOrEqual(0);
+      expect(transparent[2]).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('composite', () => {
+    it('should composite color over background with alpha', () => {
+      const fg: RGB = [0, 0, 0];
+      const bg: RGB = [1, 1, 1];
+      const result = composite(fg, bg, 0.5);
+      expect(result[0]).toBeCloseTo(0.5, 2);
+      expect(result[1]).toBeCloseTo(0.5, 2);
+      expect(result[2]).toBeCloseTo(0.5, 2);
+    });
+
+    it('should return background color when alpha = 0', () => {
+      const fg: RGB = [0, 0, 0];
+      const bg: RGB = [1, 1, 1];
+      const result = composite(fg, bg, 0);
+      expect(result[0]).toBe(1);
+      expect(result[1]).toBe(1);
+      expect(result[2]).toBe(1);
+    });
+
+    it('should return foreground color when alpha = 1', () => {
+      const fg: RGB = [0.2, 0.4, 0.6];
+      const bg: RGB = [1, 1, 1];
+      const result = composite(fg, bg, 1);
+      expect(result[0]).toBeCloseTo(0.2, 2);
+      expect(result[1]).toBeCloseTo(0.4, 2);
+      expect(result[2]).toBeCloseTo(0.6, 2);
+    });
+
+    it('should clamp alpha values outside 0-1 range', () => {
+      const fg: RGB = [0.5, 0.5, 0.5];
+      const bg: RGB = [1, 1, 1];
+      expect(composite(fg, bg, -0.5)[0]).toBe(1);
+      expect(composite(fg, bg, 1.5)[0]).toBeCloseTo(0.5, 2);
+    });
+  });
+
+  describe('formatRGBA', () => {
+    it('should format as rgb() when alpha omitted', () => {
+      const color: RGB = [0.031, 0.459, 0.882];
+      expect(formatRGBA(color)).toBe('rgb(8, 117, 225)');
+    });
+
+    it('should format as rgba() when alpha provided', () => {
+      const color: RGB = [0.031, 0.459, 0.882];
+      expect(formatRGBA(color, 0.75)).toBe('rgba(8, 117, 225, 0.75)');
+    });
+
+    it('should handle white and black', () => {
+      expect(formatRGBA([1, 1, 1])).toBe('rgb(255, 255, 255)');
+      expect(formatRGBA([0, 0, 0])).toBe('rgb(0, 0, 0)');
+    });
+
+    it('should handle alpha = 0 and 1', () => {
+      const color: RGB = [0.5, 0.5, 0.5];
+      expect(formatRGBA(color, 0)).toBe('rgba(128, 128, 128, 0.00)');
+      expect(formatRGBA(color, 1)).toBe('rgba(128, 128, 128, 1.00)');
+    });
+
+    it('should clamp alpha values outside 0-1 range', () => {
+      const color: RGB = [0.5, 0.5, 0.5];
+      expect(formatRGBA(color, -0.5)).toBe('rgba(128, 128, 128, 0.00)');
+      expect(formatRGBA(color, 1.5)).toBe('rgba(128, 128, 128, 1.00)');
+    });
+
+    it('should clamp RGB values outside 0-1 range', () => {
+      const invalid: RGB = [-0.5, 1.5, 0.5];
+      expect(formatRGBA(invalid)).toBe('rgb(0, 255, 128)');
+    });
+  });
+
+  describe('rgbToHex', () => {
+    it('should output #RRGGBB when alpha omitted', () => {
+      const color: RGB = [0.031, 0.459, 0.882];
+      expect(rgbToHex(color)).toBe('#0875e1');
+    });
+
+    it('should output #RRGGBBAA when alpha provided', () => {
+      const color: RGB = [0.031, 0.459, 0.882];
+      expect(rgbToHex(color, 0.75)).toBe('#0875e1bf');
+    });
+
+    it('should handle white and black', () => {
+      expect(rgbToHex([1, 1, 1])).toBe('#ffffff');
+      expect(rgbToHex([0, 0, 0])).toBe('#000000');
+    });
+
+    it('should handle alpha = 0 and 1', () => {
+      expect(rgbToHex([1, 1, 1], 0)).toBe('#ffffff00');
+      expect(rgbToHex([0, 0, 0], 1)).toBe('#000000ff');
+    });
+
+    it('should clamp alpha values', () => {
+      const color: RGB = [0.5, 0.5, 0.5];
+      expect(rgbToHex(color, -0.5)).toBe('#80808000');
+      expect(rgbToHex(color, 1.5)).toBe('#808080ff');
+    });
+
+    it('should pad single digit hex values', () => {
+      const color: RGB = [0.02, 0.02, 0.02];
+      const result = rgbToHex(color);
+      expect(result).toMatch(/^#[0-9a-f]{6}$/);
+      expect(result.length).toBe(7);
+    });
+
+    it('should clamp out-of-range RGB values', () => {
+      const invalid: RGB = [-0.5, 1.5, 0.5];
+      expect(rgbToHex(invalid)).toBe('#00ff80');
+      expect(rgbToHex(invalid, 0.5)).toBe('#00ff8080');
+    });
+  });
+
+  describe('alphaColor', () => {
+    describe('with RGB tuples', () => {
+      it('should calculate transparent color with minimum alpha', () => {
+        const target: RGB = [0.5, 0.5, 0.5];
+        const bg: RGB = [1, 1, 1];
+        const result = alphaColor(target, bg);
+
+        expect(result.alpha).toBeGreaterThan(0);
+        expect(result.alpha).toBeLessThanOrEqual(0.99);
+        expect(Array.isArray(result.color)).toBe(true);
+        expect(result.color.length).toBe(3);
+        expect(result.rgba).toMatch(/^rgba\(\d+, \d+, \d+, \d+\.\d+\)$/);
+        expect(result.hex).toMatch(/^#[0-9a-f]{8}$/);
+      });
+
+      it('should use provided target alpha', () => {
+        const target: RGB = [0.5, 0.5, 0.5];
+        const bg: RGB = [1, 1, 1];
+        const result = alphaColor(target, bg, 0.6);
+        expect(result.alpha).toBeCloseTo(0.6, 2);
+      });
+
+      it('should default to white background', () => {
+        const target: RGB = [0.5, 0.5, 0.5];
+        const result = alphaColor(target);
+        expect(result).toBeDefined();
+        expect(result.alpha).toBeGreaterThan(0);
+      });
+
+      it('should produce compositable result', () => {
+        const target: RGB = [0.3, 0.6, 0.9];
+        const bg: RGB = [1, 1, 1];
+        const result = alphaColor(target, bg);
+        const composited = composite(result.color, bg, result.alpha);
+        expect(composited[0]).toBeCloseTo(target[0], 1);
+        expect(composited[1]).toBeCloseTo(target[1], 1);
+        expect(composited[2]).toBeCloseTo(target[2], 1);
+      });
+    });
+
+    describe('with hex strings', () => {
+      it('should calculate transparent color from hex strings', () => {
+        const result = alphaColor('#808080', '#FFFFFF');
+        expect(result.alpha).toBeGreaterThan(0);
+        expect(result.rgba).toMatch(/^rgba\(\d+, \d+, \d+, \d+\.\d+\)$/);
+        expect(result.hex).toMatch(/^#[0-9a-f]{8}$/);
+      });
+
+      it('should default to white background', () => {
+        const result = alphaColor('#808080');
+        expect(result).toBeDefined();
+        expect(result.alpha).toBeGreaterThan(0);
+      });
+
+      it('should use provided target alpha', () => {
+        const result = alphaColor('#808080', '#FFFFFF', 0.7);
+        expect(result.alpha).toBeCloseTo(0.7, 2);
+      });
+
+      it('should handle 3-character hex codes', () => {
+        const result = alphaColor('#FFF', '#000');
+        expect(result).toBeDefined();
+        expect(result.alpha).toBeGreaterThan(0.9);
+      });
+    });
+  });
+
+  describe('round-trip conversions', () => {
+    it('should preserve color through alphaColor → composite cycle', () => {
+      const original: RGB = [0.2, 0.4, 0.8];
+      const bg: RGB = [1, 1, 1];
+      const result = alphaColor(original, bg);
+      const composited = composite(result.color, bg, result.alpha);
+      expect(composited[0]).toBeCloseTo(original[0], 1);
+      expect(composited[1]).toBeCloseTo(original[1], 1);
+      expect(composited[2]).toBeCloseTo(original[2], 1);
+    });
+
+    it('should match hex and RGB inputs', () => {
+      const hexResult = alphaColor('#0875E1', '#FFFFFF');
+      const rgbResult = alphaColor(hexToRgb('#0875E1'), hexToRgb('#FFFFFF'));
+      expect(hexResult.alpha).toBeCloseTo(rgbResult.alpha, 2);
+      expect(hexResult.hex).toBe(rgbResult.hex);
+    });
+  });
+
+  describe('input validation', () => {
+    describe('minAlpha', () => {
+      it('should throw for invalid color tuples', () => {
+        const valid: RGB = [0.5, 0.5, 0.5];
+        expect(() => minAlpha(['invalid', 0.5, 0.5] as any, valid)).toThrow(TypeError);
+      });
+
+      it('should throw for non-array input', () => {
+        const valid: RGB = [0.5, 0.5, 0.5];
+        expect(() => minAlpha({r: 0.5, g: 0.5, b: 0.5} as any, valid)).toThrow('RGB tuple');
+      });
+
+      it('should throw for wrong array length', () => {
+        const valid: RGB = [0.5, 0.5, 0.5];
+        expect(() => minAlpha([0.5, 0.5] as any, valid)).toThrow(TypeError);
+      });
+
+      it('should throw for NaN values', () => {
+        const valid: RGB = [0.5, 0.5, 0.5];
+        expect(() => minAlpha([NaN, 0.5, 0.5], valid)).toThrow(RangeError);
+      });
+
+      it('should throw for Infinity values', () => {
+        const valid: RGB = [0.5, 0.5, 0.5];
+        expect(() => minAlpha([Infinity, 0.5, 0.5], valid)).toThrow(RangeError);
+      });
+    });
+
+    describe('alphaColor', () => {
+      it('should throw for invalid target alpha', () => {
+        expect(() => alphaColor('#FFF', '#000', NaN)).toThrow(TypeError);
+        expect(() => alphaColor('#FFF', '#000', NaN)).toThrow('finite number');
+      });
+
+      it('should throw for invalid hex colors', () => {
+        expect(() => alphaColor('invalid', '#FFFFFF')).toThrow();
+      });
+
+      it('should throw for invalid background hex', () => {
+        expect(() => alphaColor('#FFFFFF', 'invalid')).toThrow();
+      });
+
+      it('should throw for invalid RGB tuple', () => {
+        expect(() => alphaColor([NaN, 0.5, 0.5])).toThrow(RangeError);
+        expect(() => alphaColor([1, 2] as any)).toThrow(TypeError);
+      });
+    });
+  });
+});

--- a/modules/react/common/spec/Alpha.spec.tsx
+++ b/modules/react/common/spec/Alpha.spec.tsx
@@ -228,6 +228,16 @@ describe('alpha utilities', () => {
         expect(composited[1]).toBeCloseTo(target[1], 1);
         expect(composited[2]).toBeCloseTo(target[2], 1);
       });
+
+      it('should return original at 100% alpha when targetAlpha cannot achieve target', () => {
+        const white: RGB = [1, 1, 1];
+        const gray: RGB = [0.5, 0.5, 0.5];
+        const result = alphaColor(white, gray, 0.5); // White on gray at 50% is impossible
+        expect(result.alpha).toBe(1);
+        expect(result.color[0]).toBeCloseTo(1, 5);
+        expect(result.color[1]).toBeCloseTo(1, 5);
+        expect(result.color[2]).toBeCloseTo(1, 5);
+      });
     });
 
     describe('with hex strings', () => {


### PR DESCRIPTION
## Summary

Adds alpha color utility for use in palette generation.

The function creates alpha-transparent versions of colors by alpha compositing the solid color with a chosen background color. This creates A25 - A100 for use on `surface` backgrounds.

## Release Category
Tokens

### Release Note
`alphaColor` is a color utility that creates a transparent version of a solid color given a background color.

## For the Reviewer

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/theming/palette/alpha.ts`  -->

## Areas for Feedback? (optional)

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

## Testing Manually

Tests are written in `Alpha.spec.tsx`

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
